### PR TITLE
Tweaking delays to try and fix startup issues

### DIFF
--- a/helm/kafka/templates/kafka-proxy-deployment.yaml
+++ b/helm/kafka/templates/kafka-proxy-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         ports:
         - containerPort: {{ .Values.ports.kafkaProxy }}
         livenessProbe:
-          initialDelaySeconds: 5
+          initialDelaySeconds: 90
           tcpSocket:
             port: {{ .Values.ports.kafkaProxy }}
         resources:

--- a/helm/kafka/templates/kafka-statefulset.yaml
+++ b/helm/kafka/templates/kafka-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
         ports:
         - containerPort: {{ .Values.ports.kafka }}
         livenessProbe:
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
           tcpSocket:
             port: {{ .Values.ports.kafka }}
         volumeMounts:

--- a/helm/kafka/templates/zookeeper-deployment.yaml
+++ b/helm/kafka/templates/zookeeper-deployment.yaml
@@ -44,7 +44,7 @@ spec:
         ports:
         - containerPort: {{ .Values.ports.zookeeper }}
         livenessProbe:
-          initialDelaySeconds: 5
+          initialDelaySeconds: 30
           tcpSocket:
             port: {{ .Values.ports.zookeeper }}
         volumeMounts:


### PR DESCRIPTION
- the environments where these settings were deployed didn't experience any leader election issues in the last month