### PR TITLE
Startup order

### DIFF
--- a/helm/kafka/templates/kafka-proxy-deployment.yaml
+++ b/helm/kafka/templates/kafka-proxy-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         'apk update; apk add netcat-openbsd
         i=0;
         while [ $i -lt 120 ]; do
-          nc -zw 5 {{ $values.service.name }}-0.kafka.default.svc.cluster.local {{ $values.ports.kafka }} && break;
+          nc -zw 5 {{ .Values.service.name }}-0.kafka.default.svc.cluster.local {{ .Values.ports.kafka }} && break;
           let i=i+5;
         done']
       containers:

--- a/helm/kafka/templates/kafka-statefulset.yaml
+++ b/helm/kafka/templates/kafka-statefulset.yaml
@@ -42,7 +42,7 @@ spec:
         'apk update; apk add netcat-openbsd
         i=0;
         while [ $i -lt 120 ]; do
-          nc -zw 5 kafka-zookeeper 2181 {{ $values.service.name }}-zookeeper {{ $values.ports.zookeeper }} && break;
+          nc -zw 5 kafka-zookeeper 2181 {{ .Values.service.name }}-zookeeper {{ .Values.ports.zookeeper }} && break;
           let i=i+5;
         done']
       containers:


### PR DESCRIPTION
- make kafka wait until zookeeper is up before starting up
- make kafka-proxy wait until kafka is up before starting up
- this is an attempt at resolving the `consumer destroyed` errors which sometimes pop up in dev after the morning cluster start