### PR TITLE
Enable ephemeral storage for k8s publish cluster

### DIFF
--- a/helm/kafka/app-configs/kafka_publishing_k8s.yaml
+++ b/helm/kafka/app-configs/kafka_publishing_k8s.yaml
@@ -1,0 +1,4 @@
+# Values used for the deployed application.
+service:
+  name: kafka
+ephemeral_storage: true


### PR DESCRIPTION
Replicate ephemeral storage for the dev publishing k8s cluster in parity with the delivery cluster.