### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/kafka-proxy_runbook.md
+++ b/runbooks/kafka-proxy_runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Kafka REST Proxy
 
 The purpose of the Kafka REST Proxy service is to provide resilient communication between the services in the UPP Kubernetes clusters and Kafka/Zookeeper service via an easier to implement REST API interface.
@@ -18,28 +22,13 @@ Platinum
 
 Production
 
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- kalin.arsov
-- mihail.mihaylov
-- elitsa.pavlova
-- hristo.georgiev
-
 ## Host Platform
 
 AWS
 
 ## Architecture
 
-This service runs a Docker image defined in https://github.com/Financial-Times/kafka-proxy . The image is based on a fork of an old version of https://github.com/confluentinc/kafka-rest .
+This service runs a Docker image defined in <https://github.com/Financial-Times/kafka-proxy> . The image is based on a fork of an old version of <https://github.com/confluentinc/kafka-rest> .
 It connects to the UPP Kafka and Zookeeper services and provides a RESTful API to other services to consume and produces messages from/to Kafka.
 
 ## Contains Personal Data
@@ -50,10 +39,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- upp-kafka
-- upp-zookeeper
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -72,10 +70,10 @@ FullyAutomated
 The service is deployed in both Publishing and Delivery clusters.
 
 The failover guide for the Delivery clusters is located here:
-https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/delivery-cluster
+<https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/delivery-cluster>
 
 The failover guide for the Publishing clusters is located here:
-https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/publishing-cluster
+<https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/publishing-cluster>
 
 ## Data Recovery Process Type
 
@@ -97,6 +95,14 @@ Manual
 
 A lot of services depend on this service so a failover is required during release.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -110,18 +116,17 @@ To rotate credentials you need to login to a particular cluster and update varni
 
 The Kafka REST proxy doesn't have monitoring of its own but several services which connect to it have healthchecks for kafka-proxy connectivity, e.g.:
 
-- Publishing-Prod-EU Publish Availability Monitor service health: https://upp-prod-publish-eu.upp.ft.com/__health/__pods-health?service-name=publish-availability-monitor
-- Publishing-Prod-US Publish Availability Monitor service health: https://upp-prod-publish-us.upp.ft.com/__health/__pods-health?service-name=publish-availability-monitor
-- Delivery-Prod-EU Methode Article Mapper health: https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=methode-article-mapper
-- Delivery-Prod-US Methode Article Mapper health: https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=methode-article-mapper
+*   Publishing-Prod-EU Publish Availability Monitor service health: <https://upp-prod-publish-eu.upp.ft.com/__health/__pods-health?service-name=publish-availability-monitor>
+*   Publishing-Prod-US Publish Availability Monitor service health: <https://upp-prod-publish-us.upp.ft.com/__health/__pods-health?service-name=publish-availability-monitor>
+*   Delivery-Prod-EU Methode Article Mapper health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=methode-article-mapper>
+*   Delivery-Prod-US Methode Article Mapper health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=methode-article-mapper>
 
 ## First Line Troubleshooting
 
-https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting
+<https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>
 
 ## Second Line Troubleshooting
 
 Please refer to the GitHub repository README for troubleshooting information.
 
-Additionally you can check the old Kafka REST proxy guide https://sites.google.com/a/ft.com/universal-publishing/ops-guides/panic-guides/kafka-rest-proxy-guide
-
+Additionally you can check the old Kafka REST proxy guide <https://sites.google.com/a/ft.com/universal-publishing/ops-guides/panic-guides/kafka-rest-proxy-guide>

--- a/runbooks/upp-kafka_runbook.md
+++ b/runbooks/upp-kafka_runbook.md
@@ -1,10 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Kafka
 
 UPP Kafka is the deployment of Apache Kafka within the UPP clusters. Apache Kafka is an open-source stream-processing software platform aiming to provide a unified, high-throughput, low-latency platform for handling real-time data feeds.
 
+## Code
+
+upp-kafka
+
 ## Primary URL
 
-<https://github.com/Financial-Times/upp-kafka>
+https://github.com/Financial-Times/upp-kafka
 
 ## Service Tier
 
@@ -13,22 +21,6 @@ Platinum
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- mihail.mihaylov
-- hristo.georgiev
-- elitsa.pavlova
-- kalin.arsov
-- boyko.boykov
 
 ## Host Platform
 
@@ -48,9 +40,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- upp-zookeeper
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -95,6 +97,14 @@ Manual
 
 Manual failover is needed when a new version of the service is deployed to production because the publishing pipeline is depending on it.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -106,10 +116,11 @@ To access the service clients need to provide basic auth credentials. To rotate 
 ## Monitoring
 
 UPP Kafka doesn't have monitoring of its own but several services which connect to it have healthchecks for Kafka connectivity, e.g.:
-- Publishing EU Native Ingester service health: <https://upp-prod-publish-eu.upp.ft.com/__health/__pods-health?service-name=native-ingester-cms>
-- Publishing US Native Ingester service health: <https://upp-prod-publish-us.upp.ft.com/__health/__pods-health?service-name=native-ingester-cms>
-- Delivery EU PAC Annotations Mapper service health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=pac-annotations-mapper>
-- Delivery US PAC Annotations Mapper service health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=pac-annotations-mapper>
+
+*   Publishing EU Native Ingester service health: <https://upp-prod-publish-eu.upp.ft.com/__health/__pods-health?service-name=native-ingester-cms>
+*   Publishing US Native Ingester service health: <https://upp-prod-publish-us.upp.ft.com/__health/__pods-health?service-name=native-ingester-cms>
+*   Delivery EU PAC Annotations Mapper service health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=pac-annotations-mapper>
+*   Delivery US PAC Annotations Mapper service health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=pac-annotations-mapper>
 
 Additionally, the UPP Kafka Lagcheck service is depending on Kafka and ZooKeeper and one can check its health status.
 

--- a/runbooks/upp-zookeeper_runbook.md
+++ b/runbooks/upp-zookeeper_runbook.md
@@ -1,10 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - ZooKeeper
 
 UPP ZooKeeper is the deployment of Apache ZooKeeper within the UPP clusters used by UPP Kafka. Apache ZooKeeper is an open-source service for distributed systems offering a hierarchical key-value store, which is used to provide a distributed configuration service, synchronization service, and naming registry for large distributed systems.
 
+## Code
+
+upp-zookeeper
+
 ## Primary URL
 
-<https://github.com/Financial-Times/upp-kafka>
+https://github.com/Financial-Times/upp-kafka
 
 ## Service Tier
 
@@ -13,22 +21,6 @@ Platinum
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- mihail.mihaylov
-- hristo.georgiev
-- elitsa.pavlova
-- kalin.arsov
-- boyko.boykov
 
 ## Host Platform
 
@@ -45,6 +37,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -88,6 +94,14 @@ Manual
 
 Manual failover is needed when a new version of the service is deployed to production because the publishing pipeline is depending on it.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -99,10 +113,11 @@ To access the service clients need to provide basic auth credentials. To rotate 
 ## Monitoring
 
 UPP ZooKeeper doesn't have monitoring of its own but the UPP Kafka Lagcheck service is depending on Kafka and ZooKeeper and one can check its health status:
-- Publishing EU UPP Kafka Lagcheck service health: <https://upp-prod-publish-eu.upp.ft.com/__health/__pods-health?service-name=kafka-lagcheck>
-- Publishing US UPP Kafka Lagcheck service health: <https://upp-prod-publish-us.upp.ft.com/__health/__pods-health?service-name=kafka-lagcheck>
-- Delivery EU UPP Kafka Lagcheck service health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=kafka-lagcheck>
-- Delivery US UPP Kafka Lagcheck service health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=kafka-lagcheck>
+
+*   Publishing EU UPP Kafka Lagcheck service health: <https://upp-prod-publish-eu.upp.ft.com/__health/__pods-health?service-name=kafka-lagcheck>
+*   Publishing US UPP Kafka Lagcheck service health: <https://upp-prod-publish-us.upp.ft.com/__health/__pods-health?service-name=kafka-lagcheck>
+*   Delivery EU UPP Kafka Lagcheck service health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=kafka-lagcheck>
+*   Delivery US UPP Kafka Lagcheck service health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=kafka-lagcheck>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/upp-kafka/blob/runbook-no-relationships-2021-03-19/runbooks/kafka-proxy_runbook.md) file has been automatically regenerated from the Biz Ops data for the **kafka-proxy** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **kafka-proxy** system in [Biz Ops](https://biz-ops.in.ft.com/System/kafka-proxy).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
